### PR TITLE
Fix busAutoComplete error

### DIFF
--- a/src/components/Form/Step7AddService/AddTramService/AddTramService.js
+++ b/src/components/Form/Step7AddService/AddTramService/AddTramService.js
@@ -35,7 +35,7 @@ const AddTramService = () => {
 
   // Helper booleans
   const anyStopsSelected = TramLines && TramLines.length > 0;
-  const isFullLineSelected = selectableTramLineIds.some((lineId) => LineId.includes(lineId));
+  const isFullLineSelected = selectableTramLineIds.some((lineId) => LineId.indexOf(lineId) > -1);
 
   return (
     <>

--- a/src/components/Form/Step8SearchForService/AutoComplete/BusAutoComplete/BusAutoComplete.js
+++ b/src/components/Form/Step8SearchForService/AutoComplete/BusAutoComplete/BusAutoComplete.js
@@ -20,9 +20,15 @@ const BusAutoComplete = ({ closeAutoComplete }) => {
   const resultsList = useRef(null);
   const debounceInput = useRef(null);
 
+  // Remove all spaces for the query so the user can still get results when query is formatted incorrectly
+  const formatQuery = (queryString) => {
+    if (!queryString) return '';
+    return queryString.replace(/\s/g, '').trim();
+  };
+
   // customHook used to fetch results based on query
   const { loading, errorInfo, results } = useAutoCompleteAPI(
-    `/bus/v1/service?q=${encodeURI(query && query.replaceAll(' ', '').trim())}`,
+    `/bus/v1/service?q=${encodeURI(formatQuery(query))}`,
     'bus',
     query
   );

--- a/src/components/Form/Step8SearchForService/AutoComplete/TrainAutoComplete/TrainAutoCompleteSelectLines.js
+++ b/src/components/Form/Step8SearchForService/AutoComplete/TrainAutoComplete/TrainAutoCompleteSelectLines.js
@@ -39,7 +39,7 @@ const TrainAutoCompleteSelectLines = ({
   // Run on change of select box
   const handleChange = (val) => {
     // If the selectedLine contains our line...
-    if (selectedLines.includes(val)) {
+    if (selectedLines.indexOf(val) > -1) {
       setSelectedLines((prev) => prev.filter((item) => item !== val)); // ...filter/remove it from the array
     } else {
       setSelectedLines((prev) => [...prev, val]); // Else, add it to the array
@@ -112,7 +112,7 @@ const TrainAutoCompleteSelectLines = ({
                 <div className="wmnds-fe-checkboxes__container wmnds-m-b-none">
                   {/* Right side for remove service button */}
                   <input
-                    checked={selectedLines.includes(line)}
+                    checked={selectedLines.indexOf(line) > -1}
                     value={line}
                     onChange={(e) => handleChange(e.target.value)}
                     className="wmnds-fe-checkboxes__input"

--- a/src/components/Form/Step8SearchForService/AutoComplete/TrainAutoComplete/TrainAutoCompleteSelectLines/TrainAutoCompleteSelectLines.js
+++ b/src/components/Form/Step8SearchForService/AutoComplete/TrainAutoComplete/TrainAutoCompleteSelectLines/TrainAutoCompleteSelectLines.js
@@ -36,7 +36,7 @@ const TrainAutoCompleteSelectLines = ({ setMode, trainStations }) => {
   // Run on change of select box
   const handleChange = (val) => {
     // If the selectedLine contains our line...
-    if (selectedLines.includes(val)) {
+    if (selectedLines.indexOf(val) > -1) {
       setSelectedLines((prev) => prev.filter((item) => item !== val)); // ...filter/remove it from the array
     } else {
       setSelectedLines((prev) => [...prev, val]); // Else, add it to the array
@@ -113,7 +113,7 @@ const TrainAutoCompleteSelectLines = ({ setMode, trainStations }) => {
                   <div className="wmnds-fe-checkboxes__container wmnds-m-b-none">
                     {/* Right side for remove service button */}
                     <input
-                      defaultChecked={selectedLines.includes(line)}
+                      defaultChecked={selectedLines.indexOf(line) > -1}
                       value={line}
                       onChange={(e) => handleChange(e.target.value)}
                       className="wmnds-fe-checkboxes__input"

--- a/src/components/Form/Step8SearchForService/AutoComplete/TramAutoComplete/TramAutoCompleteSelectLine.js
+++ b/src/components/Form/Step8SearchForService/AutoComplete/TramAutoComplete/TramAutoCompleteSelectLine.js
@@ -10,15 +10,15 @@ import s from '../ServiceAutocomplete.module.scss';
 const TramAutoCompleteSelectLine = ({ selectedLines, setSelectedLines }) => {
   const { selectableTramLineInfo } = useSelectableTramLines();
   // Filter out any non-tram lines
-  const selectedTramLines = selectedLines.filter((line) =>
-    selectableTramLineInfo.map((selectableLine) => selectableLine.id).includes(line)
+  const selectedTramLines = selectedLines.filter(
+    (line) => selectableTramLineInfo.map((selectableLine) => selectableLine.id).indexOf(line) > -1
   );
   const [checked, setChecked] = useState(selectedTramLines || []); // Local state to keep track of checked item
 
   const handleChange = (e) => {
     const id = e.target.value;
     setChecked((prevState) => {
-      if (!prevState.includes(id)) return [...prevState, id];
+      if (!prevState.indexOf(id) > -1) return [...prevState, id];
       return prevState.filter((checkedId) => checkedId !== id);
     });
   };
@@ -45,7 +45,7 @@ const TramAutoCompleteSelectLine = ({ selectedLines, setSelectedLines }) => {
               <div className="wmnds-fe-checkboxes__container wmnds-m-b-none">
                 {/* Right side for remove service button */}
                 <input
-                  checked={checked.includes(line.id)}
+                  checked={checked.indexOf(line.id) > -1}
                   value={line.id}
                   onChange={handleChange}
                   className="wmnds-fe-checkboxes__input"

--- a/src/components/Form/Step8SearchForService/AutoComplete/customHooks/useAutoCompleteAPI.js
+++ b/src/components/Form/Step8SearchForService/AutoComplete/customHooks/useAutoCompleteAPI.js
@@ -23,25 +23,33 @@ const useAutoCompleteAPI = (apiPath, mode, query) => {
         })
         .then((response) => {
           setLoading(false); // Set loading state to false after data is received
+          const { data, metroStopSearch, services } = response.data; // destructure (unused vars will be undefined)
+          let newResults = [];
+          let message;
           // BUS
           if (mode === 'bus') {
-            setResults(response.data.services || []);
+            newResults = services || [];
+            message =
+              'Make sure that you enter the bus service number and try again. For example, X8 or 101.';
           }
           // TRAM
           else if (mode === 'tram') {
-            setResults(response.data.metroStopSearch || []);
+            newResults = metroStopSearch || [];
           }
           // TRAIN
           else if (mode === 'train') {
-            setResults(response.data.data || []);
+            newResults = data || [];
           }
 
-          if ((!response.data.data || !response.data.services) && mounted) {
+          // Set the new results
+          setResults(newResults);
+
+          if (!newResults.length && mounted) {
             // If there is no bus data and the component is mounted (must be mounted or we will be creating an event on unmounted error)...
             // if no bus data, set error
             setErrorInfo({
               title: 'No results found',
-              message: 'Make sure you are looking for the right service, and try again.',
+              message: message || 'Make sure you are looking for the right service, and try again.',
             });
           }
         })

--- a/src/components/Form/useSelectableTramLines.js
+++ b/src/components/Form/useSelectableTramLines.js
@@ -12,7 +12,7 @@ const useSelectableTramLines = () => {
 
   const filterTramLineInfo = (lineIds) => {
     if (!lineIds.length) return [];
-    return selectableTramLineInfo.filter((line) => lineIds.includes(line.id));
+    return selectableTramLineInfo.filter((line) => lineIds.indexOf(line.id) > -1);
   };
 
   return { selectableTramLineInfo, selectableTramLineIds, filterTramLineInfo };


### PR DESCRIPTION
Fix an issue introduced in #202. `busAutoComplete` would error because of `replaceAll(...)`

PR also includes replacing `array.includes(...)` with `array.indexOf(...) > -1` to be safe for ie 11