### PR TITLE
Adding quiet hours and days in disruptions signup page (#281)

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,5 @@
 REACT_APP_WMNDS_VERSION = 1.7.3
 
 # Variables that control the site title and meta descriptions
-REACT_APP_TITLE = "Sign up to email alerts about disruption"
-REACT_APP_DESCRIPTION= "Sign up to email alerts about disruption - West Midlands Network"
+REACT_APP_TITLE = "Sign up to alerts about disruptions"
+REACT_APP_DESCRIPTION= "Sign up to alerts about disruption - Transport for West Midlands"

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # developemnt API and keys
-REACT_APP_API_HOST='https://rtccdisruptions6zqwajo6s.azurewebsites.net'
+REACT_APP_API_HOST='https://rtccdisruptionsbfasldoiz.azurewebsites.net'
 # Autocomplete API
 REACT_APP_AUTOCOMPLETE_API='https://wmca-api-portal-staging.azure-api.net'
 REACT_APP_AUTOCOMPLETE_API_KEY='0d4cca4a2c5d40c3bfbbfe45d1bbf294'

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,13 +14,13 @@ package = "@sentry/netlify-build-plugin"
 # Use staging for branch deploys for next-release
 # So that dummy data from testing does not enter live DB
 [context."next-release".environment]
-  REACT_APP_API_HOST="https://rtccdisruptions6zqwajo6s.azurewebsites.net"
+  REACT_APP_API_HOST="https://rtccdisruptionsbfasldoiz.azurewebsites.net"
   REACT_APP_AUTOCOMPLETE_API="https://wmca-api-portal-staging.azure-api.net"
   REACT_APP_AUTOCOMPLETE_API_KEY="0d4cca4a2c5d40c3bfbbfe45d1bbf294"
   REACT_APP_ROADS_AUTOCOMPLETE_KEY="e0c1216f818a41be8d528ac1d4f7ebfd"
 
 [context.deploy-preview.environment]
-  REACT_APP_API_HOST="https://rtccdisruptions6zqwajo6s.azurewebsites.net"
+  REACT_APP_API_HOST="https://rtccdisruptionsbfasldoiz.azurewebsites.net"
   REACT_APP_AUTOCOMPLETE_API="https://wmca-api-portal-staging.azure-api.net"
   REACT_APP_AUTOCOMPLETE_API_KEY="0d4cca4a2c5d40c3bfbbfe45d1bbf294"
   REACT_APP_ROADS_AUTOCOMPLETE_KEY="e0c1216f818a41be8d528ac1d4f7ebfd"

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
 
-    <title>%REACT_APP_TITLE% - West Midlands Network</title>
+    <title>%REACT_APP_TITLE% - Transport West Midlands</title>
     <meta name="description" content="%REACT_APP_DESCRIPTION%" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -102,6 +102,7 @@
         padding: 0;
         background-color: #f3f2f1;
       }
+      .wmnds-header--mega-menu {display: none}
     </style>
 
     <!-- Google Tag Manager (noscript) -->
@@ -130,21 +131,8 @@
     <div id="root"></div>
 
     <!-- Footer -->
-    <footer class="wmnds-footer wmnds-footer--mobile-app">
-      <div class="wmnds-container wmnds-grid">
-        <div class="wmnds-col-1 wmnds-col-md-1-2">Copyright West Midlands Network &copy; 2021</div>
-        <div class="wmnds-col-1 wmnds-col-md-1-2">
-          <a
-            href="https://www.networkwestmidlands.com/privacy-cookies-policy/"
-            title="Privacy and cookies policy"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="wmnds-footer__link wmnds-link"
-            >Privacy & Cookies Policy</a
-          >
-        </div>
-      </div>
-    </footer>
+    <script src="https://cloudcdn.wmca.org.uk/tfwmassets/js/header-footer.min.js"></script>
+
     <!-- End footer -->
 
     <!-- Ajax SVG in, SVGS are referenced in app (Icon component) -->

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "short_name": "WMN - Sign up to email alerts about disruption",
-  "name": "Sign up to email alerts about disruption - West Midlands Network ",
-  "description": "Sign up to email alerts about disruption section of the West Midlands Network website",
+  "short_name": "WMN - Sign up to alerts about disruption",
+  "name": "Sign up to alerts about disruption - West Midlands Network ",
+  "description": "Sign up to alerts about disruption section of the West Midlands Network website",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/assets/styles/_vars.scss
+++ b/src/assets/styles/_vars.scss
@@ -18,7 +18,8 @@ $palettes: (
   information: #84329b,
   disable: #676869,
   plannedDisruption: #ffdd00,
-  background: #f3f2f1
+  background: #f3f2f1,
+  hover: #e2cee7
 );
 
 $white: #ffffff;

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -26,7 +26,7 @@ function Breadcrumb() {
             className="wmnds-breadcrumb__link wmnds-breadcrumb__link--current"
             aria-current="page"
           >
-            Sign up to email alerts about disruption
+            Sign up to alerts about disruption
           </a>
         </li>
       </ol>

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -16,6 +16,8 @@ import Step6EmailAlert from './Step6EmailAlert/Step6EmailAlert';
 import Step7AddService from './Step7AddService/Step7AddService';
 import Step8SearchForService from './Step8SearchForService/Step8SearchForService';
 import Step9Confirm from './Step9Confirm/Step9Confirm';
+import StepDisruptionAlert from './StepDisruptionAlert/StepDisruptionAlert';
+import StepQuietHours from './StepQuietHours/StepQuietHours';
 import SubmitSuccess from './Step10SubmitConfirmation/Success';
 import SubmitError from './Step10SubmitConfirmation/Error';
 // Custom Hooks
@@ -49,15 +51,15 @@ const Form = ({
   useTrackFormAbandonment(currentStep, formSubmitStatus);
 
   // Show debug options for below (this should be deleted on release)
-  const debugStepOptions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+  const debugStepOptions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 
   let stepToGoTo;
 
   if (!ExistingUser) {
-    // NEW USERS: Show back button if the step is between 1 or 9
+    // NEW USERS: Show back button if the step is between 1 or 11
     if (
       currentStep > 1 &&
-      currentStep < 9 &&
+      currentStep < 11 &&
       !(currentStep === 5 && SMSAlert === 'no') &&
       !(currentStep === 7 && SMSAlert === 'no')
     ) {
@@ -67,13 +69,18 @@ const Form = ({
     if (currentStep === 5 && SMSAlert === 'no') {
       stepToGoTo = 2;
     }
-
+    if (currentStep === 4) {
+      stepToGoTo = 2;
+    }
+    if (currentStep === 2 && SMSAlert === 'yes') {
+      stepToGoTo = 4;
+    }
     if (currentStep === 7 && SMSAlert === 'no') {
       stepToGoTo = 5;
     }
   } else {
     /* EXISTING USERS: Show back button if the step is 4 or 6. Step 3 has no back button */
-    if (currentStep > 3 && currentStep < 9 && currentStep !== 6) {
+    if (currentStep > 3 && currentStep < 11 && currentStep !== 6) {
       stepToGoTo = currentStep - 1;
     }
 
@@ -100,7 +107,7 @@ const Form = ({
   }, []);
 
   useEffect(() => {
-    if (currentStep === 9) scrollToTopOfSummary();
+    if (currentStep === 11) scrollToTopOfSummary();
   }, [currentStep, scrollToTopOfSummary]);
 
   // Run! Like go get some data from an API.
@@ -118,7 +125,7 @@ const Form = ({
                 onClick={() =>
                   formDataDispatch({
                     type: 'UPDATE_STEP',
-                    payload: hasReachedConfirmation ? 9 : stepToGoTo,
+                    payload: hasReachedConfirmation ? 11 : stepToGoTo,
                   })
                 }
               >
@@ -152,10 +159,12 @@ const Form = ({
             {currentStep === 6 && <Step6EmailAlert />}
             {currentStep === 7 && <Step7AddService />}
             {currentStep === 8 && <Step8SearchForService />}
-            {currentStep === 9 && <Step9Confirm setFormSubmitStatus={setFormSubmitStatus} />}
+            {currentStep === 9 && <StepDisruptionAlert />}
+            {currentStep === 10 && <StepQuietHours />}
+            {currentStep === 11 && <Step9Confirm setFormSubmitStatus={setFormSubmitStatus} />}
             {/* for testing only */}
-            {currentStep === 10 && <SubmitSuccess />}
-            {currentStep === 11 && <SubmitError />}
+            {currentStep === 12 && <SubmitSuccess />}
+            {currentStep === 13 && <SubmitError />}
           </div>
         </div>
         {/* If in development based on envs then show form debugging */}

--- a/src/components/Form/Step10SubmitConfirmation/Success.js
+++ b/src/components/Form/Step10SubmitConfirmation/Success.js
@@ -7,7 +7,7 @@ function Success() {
   // eslint-disable-next-line no-unused-vars
   const [formDataState, formDataDispatch] = useContext(FormDataContext);
   const { isRequestingRecovery } = formDataState;
-  const { Phone, SMSAlert, EmailAlert, SMSTerms } = formDataState.formData;
+  const { Phone, SMSAlert, EmailAlert } = formDataState.formData;
 
   const alignCenter = {
     textAlign: 'center',
@@ -25,7 +25,7 @@ function Success() {
       'Visit the link in the email to manage your disruption alerts.',
       'You can now manage your services and communication preferences. You can access the page at any time by visiting the link in your email.',
     ];
-  } else if (Phone && (SMSAlert === 'yes' || SMSTerms) && EmailAlert === 'yes') {
+  } else if (Phone && SMSAlert === 'yes' && EmailAlert === 'yes') {
     /* Text messages AND Email */
     message = 'You have successfully signed up to text message and email alerts';
     steps = [
@@ -34,7 +34,7 @@ function Success() {
       'Visit the link in the confirmation email to access your disruption alert dashboard. Enter the PIN code sent to you via text message.',
       'Once you have confirmed your mobile phone number, you’ll receive disruption alerts to your mobile phone.',
     ];
-  } else if (Phone && (SMSAlert === 'yes' || SMSTerms)) {
+  } else if (Phone && SMSAlert === 'yes') {
     /* Text messages */
     message = 'You have successfully signed up to text message alerts';
     steps = [
@@ -81,7 +81,7 @@ function Success() {
 
           <p>
             <a
-              href="https://forms.office.com/Pages/ResponsePage.aspx?id=RetZCK7xCk6e-ubWa7tnLz45Weo_RTVDpYxVYcrD8wxUMzI4UlRVRVFMV002VU9FWllFTDM5QjlVWS4u"
+              href="https://forms.office.com/Pages/ResponsePage.aspx?id=RetZCK7xCk6e-ubWa7tnL51Hn3Md47tLqr_OlQdqFgtUMTE0NURDUkE2NExFWDlJTVhTQUxGTEdSWC4u"
               title="Service feedback survey"
               target="_blank"
               className="wmds-link"

--- a/src/components/Form/Step2SmsAlert/Step2SmsAlert.js
+++ b/src/components/Form/Step2SmsAlert/Step2SmsAlert.js
@@ -15,19 +15,6 @@ const Step2SmsAlert = () => {
     { text: 'No', value: 'no' },
   ];
 
-  const selectedOption = document.querySelector(
-    'input.wmnds-fe-radios__input[name="SMSAlert"]:checked'
-  );
-  let extraInfo;
-  if (selectedOption && selectedOption.value === 'no') {
-    extraInfo = (
-      <InsetText
-        classes="wmnds-m-b-lg"
-        content="You can also sign up to the text message service disruptions trial later in the disruption alerts dashboard."
-      />
-    );
-  }
-
   return (
     <form onSubmit={handleSubmit} ref={formRef} autoComplete="on">
       {/* Subsection */}
@@ -39,20 +26,23 @@ const Step2SmsAlert = () => {
       <fieldset className="wmnds-fe-fieldset wmnds-col-1">
         <legend className="wmnds-fe-fieldset__legend">
           <h2 className="wmnds-fe-question">
-            Would you like to sign up to a trial to receive text message alerts for disruptions?
+            Do you want to recieve text message alerts for disruptions?
           </h2>
           <p>We’ll automatically send text message alerts straight to your mobile phone.</p>
+          <InsetText
+            classes="wmnds-m-b-lg"
+            content="You can choose quiet hours or days. We won’t send you text or email alerts during those times."
+          />
         </legend>
 
         <Radios
           name="SMSAlert"
-          classes={extraInfo ? 'wmnds-m-b-sm' : ''}
+          classes="wmnds-m-b-sm"
           radios={radioButtons}
           fieldValidation={register({
             required: `Please select one option to proceed`,
           })}
         />
-        {extraInfo}
       </fieldset>
 
       {/* Continue button */}

--- a/src/components/Form/Step9Confirm/Step9SummarySection.js
+++ b/src/components/Form/Step9Confirm/Step9SummarySection.js
@@ -6,6 +6,7 @@ import { FormDataContext } from 'globalState/FormDataContext';
 // Components
 import RemoveService from 'components/shared/RemoveService/RemoveService';
 import Table from 'components/shared/Table/Table';
+import HoursMinutes from '../../shared/HoursMinutes/HoursMinutes';
 
 function Step9SummarySection() {
   const [formDataState, formDataDispatch] = useContext(FormDataContext);
@@ -20,6 +21,8 @@ function Step9SummarySection() {
     RoadAreas,
     LineId,
     ExistingUser,
+    QuietHours,
+    QuietDays,
   } = formDataState.formData;
   const { filterTramLineInfo } = useSelectableTramLines();
 
@@ -210,6 +213,51 @@ function Step9SummarySection() {
           </>
         )}
 
+        {!ExistingUser && QuietHours.length > 0 && (
+          <>
+            <div className="wmnds-m-b-lg wmnds-m-t-xl wmnds-grid wmnds-grid--justify-between">
+              <h3 className="wmnds-col-2-3">Daily quiet hours</h3>
+              <button
+                type="button"
+                className="wmnds-btn wmnds-btn--link"
+                onClick={() => {
+                  setStepInContext(10);
+                }}
+              >
+                Change
+              </button>
+            </div>
+            You will not receive alerts between
+            <HoursMinutes times={QuietHours} />.
+          </>
+        )}
+        {!ExistingUser && QuietDays.length > 0 && (
+          <>
+            <div className="wmnds-m-b-lg wmnds-m-t-xl wmnds-grid wmnds-grid--justify-between">
+              <h3 className="wmnds-col-2-3">Quiet days</h3>
+              <button
+                type="button"
+                className="wmnds-btn wmnds-btn--link"
+                onClick={() => {
+                  setStepInContext(10);
+                }}
+              >
+                Change
+              </button>
+            </div>
+            <p className="wmnds-col-2-3">
+              You will not receive alerts on
+              {QuietDays.length > 1 ? (
+                <span>
+                  <strong> {QuietDays.slice(0, -1).join(', ')}</strong> and{' '}
+                </span>
+              ) : (
+                ` `
+              )}
+              <strong>{QuietDays[QuietDays.length - 1]}</strong>.
+            </p>
+          </>
+        )}
         {ExistingUser && (
           <div className="wmnds-m-b-lg wmnds-m-t-xl">
             <h3 className="wmnds-col-1-3">Your services</h3>

--- a/src/components/Form/StepDisruptionAlert/StepDisruptionAlert.js
+++ b/src/components/Form/StepDisruptionAlert/StepDisruptionAlert.js
@@ -7,11 +7,10 @@ import SectionStepInfo from 'components/shared/SectionStepInfo/SectionStepInfo';
 import InsetText from 'components/shared/InsetText/InsetText';
 import useFormData from '../useFormData';
 
-const Step6EmailAlert = () => {
+const StepDisruptionAlert = () => {
   const formRef = useRef(); // Used so we can keep track of the form DOM element
   const { register, handleSubmit, showGenericError, continueButton } = useStepLogic(formRef); // Custom hook for handling continue button (validation, errors etc)
   const [radioValue, setRadioValue] = useState();
-
   const radioButtons = [
     { text: 'Yes', value: 'yes' },
     { text: 'No', value: 'no' },
@@ -19,34 +18,29 @@ const Step6EmailAlert = () => {
   const setCurrentValue = (e) => {
     setRadioValue(e.toLowerCase());
   };
+
   // Add InsetText with extra info when selected option is "no"
   let extraInfo;
+
   if (radioValue && radioValue === 'no') {
     extraInfo = (
       <InsetText
-        classes="wmnds-m-b-lg"
-        content="You can always sign up to email alerts later in the disruption alerts dashboard."
+        classes="wmnds-m-b-lg wmnds-m-t-none"
+        content="You can set quiet hours and days later in the disruption alerts dashboard."
       />
     );
   }
 
   // Check if it is an existing user already
   const { ExistingUser } = useFormData();
-  let title;
-  let text;
-  if (ExistingUser) {
-    title = 'Would you like to continue receiving email alerts?';
-    text =
-      'In addition to text message alerts, we’ll send automatic disruption alerts to your email address.';
-  } else {
-    title = 'Would you like to sign up to email alerts?';
-    text = 'You’ll receive automatic disruption alerts to your email address.';
-  }
+  const title = 'Do you want to choose when to receive disruption alerts?';
+  const text =
+    'You can set quiet hours and days so you only receive alerts when it’s best for you.';
 
   return (
     <form onSubmit={handleSubmit} ref={formRef} autoComplete="on">
       {/* Subsection */}
-      {!ExistingUser && <SectionStepInfo section="Section 1 of 2" description="About you" />}
+      {!ExistingUser && <SectionStepInfo section="Section 1 of 2" description="Services" />}
 
       {/* Show generic error message */}
       {showGenericError}
@@ -56,9 +50,8 @@ const Step6EmailAlert = () => {
           <h2 className="wmnds-fe-question">{title}</h2>
           <p>{text}</p>
         </legend>
-
         <Radios
-          name="EmailAlert"
+          name="DisruptionAlert"
           classes={extraInfo ? 'wmnds-m-b-sm' : ''}
           radios={radioButtons}
           onChange={(e) => setCurrentValue(e.target.value)}
@@ -66,7 +59,6 @@ const Step6EmailAlert = () => {
             required: `Please select one option to proceed`,
           })}
         />
-
         {extraInfo}
       </fieldset>
 
@@ -76,4 +68,4 @@ const Step6EmailAlert = () => {
   );
 };
 
-export default Step6EmailAlert;
+export default StepDisruptionAlert;

--- a/src/components/Form/StepQuietHours/AddQuietDays.js
+++ b/src/components/Form/StepQuietHours/AddQuietDays.js
@@ -1,0 +1,110 @@
+import React, { useState, useCallback, useRef } from 'react';
+// Context
+// Components
+import Button from 'components/shared/Button/Button';
+import Checkboxes from 'components/shared/FormElements/Checkboxes/Checkboxes';
+import useStepLogic from 'components/Form/useStepLogic';
+
+const AddQuietDays = () => {
+  const formRef = useRef(); // Used so we can keep track of the form DOM element
+  const { formDataState, formDataDispatch } = useStepLogic(formRef);
+  const [showDays, setShowDays] = useState(false);
+  const [confirmDays, setConfirmDays] = useState(false);
+  const { QuietDays } = formDataState.formData;
+  const checkBoxes = [
+    { text: 'Mon', value: 'Monday' },
+    { text: 'Tue', value: 'Tuesday' },
+    { text: 'Wed', value: 'Wednesday' },
+    { text: 'Thu', value: 'Thursday' },
+    { text: 'Fri', value: 'Friday' },
+    { text: 'Sat', value: 'Saturday' },
+    { text: 'Sun', value: 'Sunday' },
+  ];
+  const [days, setDays] = useState(0);
+
+  const callback = useCallback((day) => {
+    setDays(day);
+  }, []);
+
+  const handleCancelDays = () => {
+    setConfirmDays(false);
+    setShowDays(false);
+  };
+
+  const handleAddDays = () => {
+    if (days) {
+      formDataDispatch({
+        type: 'UPDATE_FORM_DATA',
+        payload: {
+          QuietDays: [...days],
+        },
+      });
+    }
+    setConfirmDays(false);
+    setShowDays(false);
+  };
+  const handleShowDays = () => {
+    setShowDays(true);
+    setConfirmDays(true);
+  };
+
+  return (
+    <>
+      <h3 className="wmnds-m-t-sm">Quiet days</h3>
+      {QuietDays && QuietDays.length < 1 ? (
+        <p>You will not receive alerts for 24 hours on selected days.</p>
+      ) : (
+        <p>
+          You will not receive alerts on
+          {QuietDays.length > 1 ? (
+            <span>
+              <strong> {QuietDays.slice(0, -1).join(', ')}</strong> and{' '}
+            </span>
+          ) : (
+            ` `
+          )}
+          <strong>{QuietDays[QuietDays.length - 1]}</strong>.
+        </p>
+      )}
+      {/* Add quiet days button */}
+      {!showDays && !confirmDays ? (
+        <div className="wmnds-col-1 wmnds-col-md-1-2">
+          <Button
+            btnClass="wmnds-btn--secondary wmnds-col-1 wmnds-m-b-sm wmnds-col-sm-auto"
+            onClick={handleShowDays}
+            text={QuietDays && QuietDays.length < 1 ? `Set quiet days` : `Edit your quiet days`}
+            aria-label={
+              QuietDays && QuietDays.length < 1 ? `Set quiet days` : `Edit your quiet days`
+            }
+          />
+        </div>
+      ) : (
+        <div>
+          <Checkboxes
+            checkboxes={checkBoxes}
+            name="Quietdays"
+            parentCallback={callback}
+            aria-label="Edit your quiet days"
+          />
+          <div className="wmnds-m-b-sm">
+            <Button
+              btnClass="wmnds-text-align-left wmnds-btn wmnds-col-sm-auto"
+              onClick={handleAddDays}
+              text="Confirm quiet days"
+              aria-label="Confirm quiet days"
+            />
+            <Button
+              btnClass="wmnds-btn--primary wmnds-m-l-lg wmnds-btn wmnds-col-sm-auto"
+              onClick={handleCancelDays}
+              text="Cancel"
+              aria-label="Cancel"
+            />
+          </div>
+        </div>
+      )}
+      <hr className="wmnds-col-1 wmnds-m-t-md wmnds-m-b-md" />
+    </>
+  );
+};
+
+export default AddQuietDays;

--- a/src/components/Form/StepQuietHours/AddQuietHours.js
+++ b/src/components/Form/StepQuietHours/AddQuietHours.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+// Context
+// Components
+import Button from 'components/shared/Button/Button';
+import useStepLogic from 'components/Form/useStepLogic';
+import QuietHoursComponent from './QuietHoursComponent';
+import HoursMinutes from '../../shared/HoursMinutes/HoursMinutes';
+
+const AddQuietHours = () => {
+  const { formDataState, formDataDispatch } = useStepLogic();
+  const [showHours, setShowHours] = useState(false);
+  const { QuietHours } = formDataState.formData;
+  const [times, setTimes] = useState({
+    id: `${Math.random()}`,
+    startHour: '00',
+    startMinute: '00',
+    endHour: '00',
+    endMinute: '00',
+  });
+
+  const handleConfirmHours = () => {
+    setShowHours(false);
+  };
+
+  const handleAddHours = () => {
+    setTimes({
+      id: `${Math.random()}`,
+      startHour: '00',
+      startMinute: '00',
+      endHour: '00',
+      endMinute: '00',
+    });
+    formDataDispatch({
+      type: 'UPDATE_FORM_DATA',
+      payload: {
+        QuietHours: [...QuietHours, times],
+      },
+    });
+  };
+  const handleShowHours = () => {
+    setShowHours(true);
+    if (QuietHours.length < 1) {
+      handleAddHours();
+    }
+  };
+
+  return (
+    <>
+      <div>
+        {/* Subsection */}
+        <h3 className="wmnds-p-t-md">Daily quiet hours</h3>
+        {QuietHours && QuietHours.length < 1 ? (
+          <p>You will not receive alerts at the selected times.</p>
+        ) : (
+          <p>
+            You will not receive alerts between
+            <HoursMinutes times={QuietHours} />.
+          </p>
+        )}
+        {/* Add quiet hours button */}
+        {!showHours || (QuietHours && QuietHours.length < 1) ? (
+          <div className="wmnds-col-1 wmnds-col-md-1-2">
+            <Button
+              btnClass="wmnds-btn--secondary wmnds-col-1 wmnds-m-b-sm wmnds-btn wmnds-col-sm-auto"
+              onClick={handleShowHours}
+              text={
+                QuietHours && QuietHours.length < 1 ? `Set quiet hours` : `Edit your quiet hours`
+              }
+            />
+          </div>
+        ) : (
+          <div>
+            {/* Show the quiet hours the user has added */}
+            {QuietHours && QuietHours.length > 0 && (
+              <>
+                {QuietHours.map((quietHours) => {
+                  return (
+                    <QuietHoursComponent
+                      mode="quietHours"
+                      quietHours={quietHours}
+                      name={`${quietHours.id}`}
+                      key={`${quietHours.id}`}
+                    />
+                  );
+                })}
+              </>
+            )}
+            <div>
+              {QuietHours && QuietHours.length < 10 && (
+                <Button
+                  btnClass="wmnds-btn--secondary wmnds-text-align-left wmnds-m-r-sm wmnds-m-b-sm"
+                  onClick={handleAddHours}
+                  text="Add another time"
+                  iconRight="general-expand"
+                />
+              )}
+              <Button
+                btnClass="wmnds-text-align-left"
+                onClick={handleConfirmHours}
+                text="Confirm quiet hours"
+              />
+            </div>
+          </div>
+        )}
+        <hr className="wmnds-col-1 wmnds-m-t-md wmnds-m-b-md" />
+      </div>
+    </>
+  );
+};
+
+export default AddQuietHours;

--- a/src/components/Form/StepQuietHours/QuietHoursComponent.js
+++ b/src/components/Form/StepQuietHours/QuietHoursComponent.js
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import useStepLogic from 'components/Form/useStepLogic';
+import Button from 'components/shared/Button/Button';
+import Dropdown from 'components/shared/FormElements/Dropdown/Dropdown';
+// Import styling
+import s from './QuietHoursComponent.module.scss';
+
+const QuietHoursComponent = ({ name, quietHours }) => {
+  const { formDataState, formDataDispatch } = useStepLogic();
+  const { QuietHours } = formDataState.formData;
+  const [hoursArray] = useState({
+    id: name,
+    startHour: quietHours.startHour,
+    startMinute: quietHours.startMinute,
+    endHour: quietHours.endHour,
+    endMinute: quietHours.endMinute,
+  });
+
+  const currentHours = QuietHours.filter((item) => item.id === hoursArray.id);
+
+  const onSelectedChange = (e) => {
+    const v = e.target.value;
+    const t = e.target.name;
+    Object.keys(hoursArray).map((item) => {
+      if (item === t) {
+        hoursArray[item] = v;
+      }
+      return item;
+    });
+    const updatedArray = QuietHours.map((a) => {
+      if (a.id === hoursArray.id) {
+        // eslint-disable-next-line no-param-reassign
+        a = hoursArray;
+      }
+      return a;
+    });
+    formDataDispatch({
+      type: 'UPDATE_FORM_DATA',
+      payload: {
+        QuietHours: [...updatedArray],
+      },
+    });
+  };
+
+  const handleRemoveHours = (id) => {
+    formDataDispatch({ type: 'REMOVE_QUIET_HOURS', payload: id });
+  };
+  const times = () => {
+    const hour = [];
+    for (let i = 0; i < 24; i += 1) {
+      hour.push(`${`0${i}`.slice(-2)}`);
+    }
+    return hour;
+  };
+  const minute = () => {
+    const j = [];
+    for (let i = 0; i < 60; i += 5) {
+      j.push(`${`0${i}`.slice(-2)}`);
+    }
+    return j;
+  };
+  const hours = times().map((i) => ({ ...i, value: i, text: i }));
+  const minutes = minute().map((i) => ({ ...i, value: i, text: i }));
+  return (
+    <>
+      <div className="wmnds-grid wmnds-grid--justify-between wmnds-grid--align-center">
+        <div className="wmnds-col-md-2-2">
+          <div>
+            <h5 className="wmnds-fe-label wmnds-m-none">Start</h5>
+            <Dropdown
+              parent={name}
+              name="startHour"
+              options={hours}
+              defaultValue={currentHours[0].startHour}
+              onChange={onSelectedChange}
+            />
+            <Dropdown
+              parent={name}
+              name="startMinute"
+              options={minutes}
+              defaultValue={currentHours[0].startMinute}
+              onChange={onSelectedChange}
+            />
+          </div>
+        </div>
+        <div className="wmnds-col-md-1-2">
+          <div>
+            <h5 className="wmnds-fe-label wmnds-m-none">End</h5>
+            <Dropdown
+              parent={name}
+              name="endHour"
+              options={hours}
+              defaultValue={currentHours[0].endHour}
+              onChange={onSelectedChange}
+            />
+            <Dropdown
+              parent={name}
+              name="endMinute"
+              options={minutes}
+              defaultValue={currentHours[0].endMinute}
+              onChange={onSelectedChange}
+            />
+          </div>
+        </div>
+        <Button
+          btnClass={`${s.button} wmnds-btn--destructive wmnds-col-md-2-1`}
+          iconRight="general-trash"
+          onClick={() => handleRemoveHours(name)}
+        />
+      </div>
+    </>
+  );
+};
+QuietHoursComponent.propTypes = {
+  name: PropTypes.string,
+  quietHours: PropTypes.oneOfType([PropTypes.shape, PropTypes.object]).isRequired,
+};
+
+QuietHoursComponent.defaultProps = {
+  name: '',
+};
+
+export default QuietHoursComponent;

--- a/src/components/Form/StepQuietHours/QuietHoursComponent.module.scss
+++ b/src/components/Form/StepQuietHours/QuietHoursComponent.module.scss
@@ -1,0 +1,12 @@
+@import '~assets/styles/vars';
+
+.button {
+  top: 5px;
+  padding: 5px;
+}
+
+.button svg {
+  width: 40px;
+  height: 40px;
+  margin-left: 0;
+}

--- a/src/components/Form/StepQuietHours/StepQuietHours.js
+++ b/src/components/Form/StepQuietHours/StepQuietHours.js
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+// Import custom hooks
+import useStepLogic from 'components/Form/useStepLogic';
+// Import components
+import SectionStepInfo from 'components/shared/SectionStepInfo/SectionStepInfo';
+import InsetText from 'components/shared/InsetText/InsetText';
+import useFormData from '../useFormData';
+import AddQuietHours from './AddQuietHours';
+import AddQuietDays from './AddQuietDays';
+
+const StepQuietHours = () => {
+  const formRef = useRef(); // Used so we can keep track of the form DOM element
+  const { handleSubmit, showGenericError, continueButton } = useStepLogic(formRef); // Custom hook for handling continue button (validation, errors etc)
+  // Add InsetText with extra info when selected option is "no"
+  let extraInfo;
+  const selectedOption = document.querySelector(
+    'input.wmnds-fe-radios__input[name="EmailAlert"]:checked'
+  );
+  if (selectedOption && selectedOption.value === 'no') {
+    extraInfo = (
+      <InsetText
+        classes="wmnds-m-b-lg"
+        content="You can always sign up to email alerts later in the disruption alerts dashboard."
+      />
+    );
+  }
+
+  // Check if it is an existing user already
+  const { ExistingUser } = useFormData();
+  const title = 'Choose when you recieve disruption alerts';
+  const text =
+    'You can set quiet hours and days so you only receive alerts when it’s best for you.';
+
+  return (
+    <form onSubmit={handleSubmit} ref={formRef} autoComplete="on">
+      {/* Subsection */}
+      {!ExistingUser && <SectionStepInfo section="Section 1 of 2" description="Services" />}
+
+      {/* Show generic error message */}
+      {showGenericError}
+
+      <fieldset className="wmnds-fe-fieldset wmnds-col-1">
+        <legend className="wmnds-fe-fieldset__legend">
+          <h2 className="wmnds-fe-question">{title}</h2>
+          <p>{text}</p>
+        </legend>
+        <AddQuietHours />
+        <AddQuietDays />
+        {extraInfo}
+      </fieldset>
+
+      {/* Continue button */}
+      {continueButton()}
+    </form>
+  );
+};
+
+export default StepQuietHours;

--- a/src/components/Form/useFormData.js
+++ b/src/components/Form/useFormData.js
@@ -18,9 +18,12 @@ const useFormData = () => {
     Phone,
     BusServices,
     TramServices,
+    QuietHours,
+    QuietDays,
     ExistingUser,
     SMSAlert,
     EmailAlert,
+    DisruptionAlert,
     SMSTerms,
   } = formDataState.formData;
   return {
@@ -30,6 +33,8 @@ const useFormData = () => {
     Phone,
     BusServices,
     TramServices,
+    QuietHours,
+    QuietDays,
     ExistingUser,
     formDataState,
     formDataDispatch,
@@ -37,6 +42,7 @@ const useFormData = () => {
     setMode,
     SMSAlert,
     EmailAlert,
+    DisruptionAlert,
     SMSTerms,
   };
 };

--- a/src/components/Form/useStepLogic.js
+++ b/src/components/Form/useStepLogic.js
@@ -30,7 +30,7 @@ const useStepLogic = (formRef) => {
 
       if (formDataState.currentStep === 2) {
         // Step2: SMS alert?  Yes -> Step 3  No -> Step 5
-        setStep(getValues().SMSAlert === 'no' ? 5 : formDataState.currentStep + 1);
+        setStep(getValues().SMSAlert === 'no' ? 5 : formDataState.currentStep + 2);
       } else if (formDataState.currentStep === 5 && formDataState.formData.SMSAlert === 'no') {
         // If user opt out of SMS Alert (on step 2), ask for email (step 5) and automatically choose the email alerts (Step 5 -> 7)
         formDataDispatch({
@@ -38,20 +38,22 @@ const useStepLogic = (formRef) => {
           payload: { EmailAlert: 'yes' },
         });
 
-        setStep(formDataState.hasReachedConfirmation ? 9 : formDataState.currentStep + 2);
+        setStep(formDataState.hasReachedConfirmation ? 11 : formDataState.currentStep + 2);
+      } else if (formDataState.currentStep === 9 && getValues().DisruptionAlert === 'no') {
+        setStep(11);
       } else {
-        setStep(formDataState.hasReachedConfirmation ? 9 : formDataState.currentStep + 1);
+        setStep(formDataState.hasReachedConfirmation ? 11 : formDataState.currentStep + 1);
       }
 
       // EXISTING USERS: exceptions to the usual workflow
       if (formDataState.formData.ExistingUser) {
         if (formDataState.currentStep === 4) {
           // Step4: Phone  ->  Step 6: Keep receiving email alerts?
-          // Step4: Phone  -> Step 9: summary  (if using is editing the phone number)
-          setStep(formDataState.hasReachedConfirmation ? 9 : 6);
+          // Step4: Phone  -> Step 11: summary  (if using is editing the phone number)
+          setStep(formDataState.hasReachedConfirmation ? 11 : 6);
         } else if (formDataState.currentStep === 6) {
-          // Step6: Keep receiving email alerts?  ->  Step 9: Summary
-          setStep(9);
+          // Step6: Keep receiving email alerts?  ->  Step 11: Summary
+          setStep(11);
         }
       }
     }

--- a/src/components/HeaderAndBreadCrumb.js
+++ b/src/components/HeaderAndBreadCrumb.js
@@ -11,7 +11,7 @@ const HeaderAndBreadcrumb = ({ isFormStarted, formSubmitStatus }) => {
             {/* <!-- Logo --> */}
             <a
               className="wmnds-header__logo-link"
-              href="//wmnetwork.co.uk"
+              href="//tfwm.org.uk"
               title="West Midlands Network Home"
             >
               <img
@@ -47,7 +47,7 @@ const HeaderAndBreadcrumb = ({ isFormStarted, formSubmitStatus }) => {
             <p className="wmnds-banner-container__text">
               This is a new service - your{' '}
               <a
-                href="https://forms.office.com/Pages/ResponsePage.aspx?id=RetZCK7xCk6e-ubWa7tnLz45Weo_RTVDpYxVYcrD8wxUMzI4UlRVRVFMV002VU9FWllFTDM5QjlVWS4u"
+                href="https://forms.office.com/Pages/ResponsePage.aspx?id=RetZCK7xCk6e-ubWa7tnL51Hn3Md47tLqr_OlQdqFgtUMTE0NURDUkE2NExFWDlJTVhTQUxGTEdSWC4u"
                 title="Service feedback survey"
                 target="_blank"
                 className="wmnds-link"

--- a/src/components/shared/FormElements/Checkboxes/Checkbox/Checkbox.js
+++ b/src/components/shared/FormElements/Checkboxes/Checkbox/Checkbox.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Import styling
+import s from './Checkbox.module.scss';
+
+const Checkbox = ({ name, fieldValidation, text, value, checked, onChange }) => {
+  return (
+    <>
+      <div>
+        <input
+          className={`${s.checkbox}`}
+          name={name}
+          type="checkbox"
+          ref={fieldValidation}
+          value={value}
+          checked={checked}
+          onChange={onChange}
+          id={text}
+        />
+        <label
+          htmlFor={text}
+          className={`wmnds-btn wmnds-btn--secondary wmnds-btn--block ${s.button} `}
+        >
+          {text}
+        </label>
+      </div>
+    </>
+  );
+};
+
+// PropTypes
+Checkbox.propTypes = {
+  name: PropTypes.string.isRequired,
+  fieldValidation: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  checked: PropTypes.bool.isRequired,
+};
+
+Checkbox.defaultProps = {
+  fieldValidation: null,
+};
+
+export default Checkbox;

--- a/src/components/shared/FormElements/Checkboxes/Checkbox/Checkbox.module.scss
+++ b/src/components/shared/FormElements/Checkboxes/Checkbox/Checkbox.module.scss
@@ -1,0 +1,23 @@
+@import '~assets/styles/vars';
+@import '~assets/styles/mixins';
+
+.checkbox {
+  position: absolute;
+  opacity: 0;
+}
+
+.checkbox:checked + .button {
+  background-color: get-color(hover);
+}
+
+.checkbox:focus + .button {
+  box-shadow: 0 0 0 2px $white, 0 0 0 4px get-color(secondary);
+}
+
+.button {
+  display: inline;
+  width: 4rem;
+  margin-right: 0.5rem;
+  margin-bottom: 2rem;
+  float: left;
+}

--- a/src/components/shared/FormElements/Checkboxes/Checkboxes.js
+++ b/src/components/shared/FormElements/Checkboxes/Checkboxes.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import dompurify from 'dompurify';
+// Import contexts
+import { useFormContext } from 'react-hook-form';
+// Import components
+import useStepLogic from 'components/Form/useStepLogic';
+import Checkbox from './Checkbox/Checkbox';
+
+const { sanitize } = dompurify;
+
+const Checkboxes = ({ name, label, checkboxes, fieldValidation, parentCallback }) => {
+  const { errors } = useFormContext();
+  const { formDataState } = useStepLogic();
+  const { QuietDays } = formDataState.formData;
+  const selectedDays = checkboxes.map((a) => QuietDays.includes(a.value));
+  const [checkedState, setCheckedState] = useState(selectedDays);
+
+  const handleOnChange = (position) => {
+    const updatedCheckedState = checkedState.map((item, index) =>
+      index === position ? !item : item
+    );
+    setCheckedState(updatedCheckedState);
+    const daysSelected = updatedCheckedState.map((currentState, index) => {
+      if (currentState === true) {
+        return checkboxes[index].value;
+      }
+      return null;
+    });
+    const filtered = daysSelected.filter((a) => a);
+    parentCallback(filtered);
+  };
+  return (
+    <div>
+      <fieldset className="wmnds-fe-fieldset">
+        <legend className="wmnds-fe-fieldset__legend">
+          {label && <h2 className="wmnds-fe-question">{label}</h2>}
+          {/* If there is an error, show here */}
+          {errors[name] && (
+            <span
+              className="wmnds-fe-error-message"
+              dangerouslySetInnerHTML={{
+                __html: sanitize(errors[name].message),
+              }}
+            />
+          )}
+        </legend>
+        <div className="wmnds-fe-checkboxes">
+          {/* Loop through checkboxes and display each checkbox */}
+          {checkboxes.map(({ text, value }, index) => (
+            <Checkbox
+              key={text}
+              name={name}
+              text={text}
+              value={value}
+              fieldValidation={fieldValidation}
+              checked={checkedState[index]}
+              onChange={() => handleOnChange(index)}
+              aria-label={name}
+            />
+          ))}
+        </div>
+      </fieldset>
+    </div>
+  );
+};
+
+// PropTypes
+Checkboxes.propTypes = {
+  fieldValidation: PropTypes.func,
+  parentCallback: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  checkboxes: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string, PropTypes.string)).isRequired,
+};
+
+Checkboxes.defaultProps = {
+  fieldValidation: null,
+  label: null,
+};
+
+export default Checkboxes;

--- a/src/components/shared/FormElements/Dropdown/Dropdown.js
+++ b/src/components/shared/FormElements/Dropdown/Dropdown.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import dompurify from 'dompurify';
+import PropTypes from 'prop-types';
+import useStepLogic from 'components/Form/useStepLogic';
+
+// Import styling
+import s from './Dropdown.module.scss';
+
+const { sanitize } = dompurify;
+
+const Dropdown = ({
+  name,
+  hint,
+  parent,
+  label,
+  error,
+  options,
+  defaultValue,
+  onChange,
+  onBlur,
+}) => {
+  const { formDataState } = useStepLogic();
+  const defaultSelectValue = defaultValue || formDataState.formData.QuietHours[parent]; // cast to acceptable types for a select element
+
+  return (
+    <div className={`${s.select} wmnds-fe-group wmnds-m-b-md`}>
+      <fieldset className="wmnds-fe-fieldset">
+        <div className={`wmnds-fe-dropdown${error ? ' wmnds-fe-group--error' : ''}`}>
+          {/* If there is an error, show here */}
+          {error && (
+            <span
+              className="wmnds-fe-error-message"
+              dangerouslySetInnerHTML={{
+                __html: sanitize(error.message),
+              }}
+            />
+          )}
+          <label className="wmnds-fe-label" htmlFor={name}>
+            {hint}
+          </label>
+          <select
+            className="wmnds-fe-dropdown__select"
+            id={name}
+            name={name}
+            defaultValue={defaultSelectValue || ''}
+            onChange={onChange}
+            onBlur={onBlur}
+          >
+            {options.map((option) => (
+              <option key={option.text} value={option.value}>
+                {option.text}
+              </option>
+            ))}
+          </select>
+        </div>
+      </fieldset>
+    </div>
+  );
+};
+
+// Set props
+Dropdown.propTypes = {
+  name: PropTypes.string,
+  parent: PropTypes.string,
+  hint: PropTypes.string,
+  error: PropTypes.string,
+  label: PropTypes.string,
+  defaultValue: PropTypes.string,
+  options: PropTypes.PropTypes.oneOfType([PropTypes.shape, PropTypes.array]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
+};
+
+Dropdown.defaultProps = {
+  name: '',
+  parent: '',
+  hint: '',
+  error: '',
+  label: null,
+  defaultValue: '',
+  onBlur: () => {},
+};
+export default Dropdown;

--- a/src/components/shared/FormElements/Dropdown/Dropdown.module.scss
+++ b/src/components/shared/FormElements/Dropdown/Dropdown.module.scss
@@ -1,0 +1,7 @@
+@import '~assets/styles/vars';
+
+.select {
+  display: inline-block;
+  width: 100px;
+  margin-right: 0.5rem;
+}

--- a/src/components/shared/FormElements/Radios/Radio/Radio.js
+++ b/src/components/shared/FormElements/Radios/Radio/Radio.js
@@ -7,7 +7,7 @@ import { FormDataContext } from 'globalState/FormDataContext';
 
 const { sanitize } = dompurify;
 
-const Radio = ({ name, fieldValidation, text, value }) => {
+const Radio = ({ name, fieldValidation, text, value, onChange }) => {
   const [formDataState] = useContext(FormDataContext); // Get the state of form data from FormDataContext
 
   return (
@@ -25,6 +25,7 @@ const Radio = ({ name, fieldValidation, text, value }) => {
           ref={fieldValidation}
           value={value}
           defaultChecked={formDataState.formData[name] === value}
+          onChange={onChange}
         />
         <span className="wmnds-fe-radios__checkmark" />
       </label>
@@ -36,12 +37,14 @@ const Radio = ({ name, fieldValidation, text, value }) => {
 Radio.propTypes = {
   name: PropTypes.string.isRequired,
   fieldValidation: PropTypes.func,
+  onChange: PropTypes.func,
   text: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
 };
 
 Radio.defaultProps = {
   fieldValidation: null,
+  onChange: null,
 };
 
 export default Radio;

--- a/src/components/shared/FormElements/Radios/Radios.js
+++ b/src/components/shared/FormElements/Radios/Radios.js
@@ -8,7 +8,7 @@ import Radio from './Radio/Radio';
 
 const { sanitize } = dompurify;
 
-const Radios = ({ name, classes, label, radios, fieldValidation }) => {
+const Radios = ({ name, classes, label, radios, fieldValidation, onChange }) => {
   const { errors } = useFormContext();
 
   return (
@@ -35,6 +35,7 @@ const Radios = ({ name, classes, label, radios, fieldValidation }) => {
               text={radio.text}
               value={radio.value}
               fieldValidation={fieldValidation}
+              onChange={onChange}
             />
           ))}
         </div>
@@ -46,6 +47,7 @@ const Radios = ({ name, classes, label, radios, fieldValidation }) => {
 // PropTypes
 Radios.propTypes = {
   fieldValidation: PropTypes.func,
+  onChange: PropTypes.func,
   classes: PropTypes.string,
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
@@ -54,6 +56,7 @@ Radios.propTypes = {
 
 Radios.defaultProps = {
   fieldValidation: null,
+  onChange: null,
   classes: null,
   label: null,
 };

--- a/src/components/shared/HoursMinutes/HoursMinutes.js
+++ b/src/components/shared/HoursMinutes/HoursMinutes.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const HoursMinutes = ({ times }) => {
+  return times.map((time, i) => {
+    let last = false;
+    if (times.length - 1 === i) {
+      last = true;
+    }
+    return (
+      <span key={Math.random()}>
+        <strong> {time.startHour}</strong>:<strong>{time.startMinute} </strong>
+        and
+        <strong> {time.endHour}</strong>:<strong>{time.endMinute}</strong>
+        {!last && <span>,</span>}
+      </span>
+    );
+  });
+};
+HoursMinutes.propTypes = {
+  times: PropTypes.oneOfType([PropTypes.shape, PropTypes.array]).isRequired,
+};
+export default HoursMinutes;

--- a/src/globalState/FormDataContext.js
+++ b/src/globalState/FormDataContext.js
@@ -28,6 +28,8 @@ export const FormDataProvider = (props) => {
       TramLines: [],
       Trains: [],
       RoadAreas: [],
+      QuietHours: [],
+      QuietDays: [],
     },
     formRef: '',
     hasReachedConfirmation: false,
@@ -110,7 +112,16 @@ export const FormDataProvider = (props) => {
           },
         };
       }
-
+      // Remove the quite hours from form data
+      case 'REMOVE_QUIET_HOURS': {
+        return {
+          ...state,
+          formData: {
+            ...state.formData,
+            QuietHours: state.formData.QuietHours.filter((hours) => action.payload !== hours.id),
+          },
+        };
+      }
       // Update service mode
       case 'UPDATE_MODE': {
         return {


### PR DESCRIPTION
* Adding quiet hours and days in disruptions signup page

* Fixing label for checkbox

* Updating state

* Updating state

* Updating aria labels

* Adding functionality to strip overlapping times

* Adding functionality to strip overlapping times

Co-authored-by: Mushtaque Ahmed <mushtaque.ahmed@wmca.org.uk>